### PR TITLE
Work around problems deserializing errors.

### DIFF
--- a/lib/batchy/batch.rb
+++ b/lib/batchy/batch.rb
@@ -114,8 +114,17 @@ module Batchy
 
     # Conversely, the backtrace is added to the error after a read
     def error
-      err = read_attribute(:error)
-      return err if err.blank?
+      err = nil
+      # YAML parsers packaged with some versions of ruby have trouble
+      # deserializing exception objects, so if we fail, just wrap the raw YAML
+      # in a wrapper object that looks and quacks mostly like an exception
+      # object.
+      begin
+        err = read_attribute(:error)
+        return err if err.blank?
+      rescue
+        err = ErrWrapper.new(read_attribute_before_type_cast(:error),[])
+      end
 
       backtrace = read_attribute(:backtrace)
       if err.respond_to?(:set_backtrace)
@@ -264,5 +273,10 @@ module Batchy
       @ensure_callbacks = []
       @ignore_callbacks = []
     end
+  end
+  
+  class ErrWrapper < Struct.new(:message, :backtrace)
+    alias_method :to_s, :message
+    alias_method :set_backtrace, :"backtrace="
   end
 end


### PR DESCRIPTION
Nesting batches using the following pattern for error handling (bubbling errors from inner batches out to outer ones) often fails due to an issue in the YAML parser distributed with some versions of ruby:

``` ruby
Batchy.run(...) do |outer|
  # ...
  err = nil
  Batchy.run(...) do |inner|
    inner.on_failure { err = inner.error }
    # ...
  end
  raise err if err
  # ...
end
```

This pull request modifies `Batchy::Batch#error` so that, in the event of a deserialization error, the method returns an error-like object with the serialized form of the actual error as its message, and the backtrace of the original error (if any) as its backtrace.
